### PR TITLE
ROCANA-2264 Add locking to map accesses to avoid races

### DIFF
--- a/config.go
+++ b/config.go
@@ -132,7 +132,7 @@ func (log Logger) LoadConfiguration(filename string) {
 			continue
 		}
 
-		log[xmlfilt.Tag] = &Filter{lvl, filt}
+		log.filters[xmlfilt.Tag] = &Filter{lvl, filt}
 	}
 }
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	Global Logger
+	Global *Logger
 )
 
 func init() {


### PR DESCRIPTION
The big outcome here is that closing a Writer and removing it from the Logger is atomic, so we don't have to worry about closed writers being written to. Multiple routines can still log concurrently.

This is a breaking change to the API, especially since the documentation recommends using `make(Logger)` over `NewLogger()`. The alternative would be adding locking and state to every Writer to make `LogWrite()` after `Close()` a no-op.