### PR TITLE
ROCANA-2388 Add support for millisecond timestamps

### DIFF
--- a/log4go_test.go
+++ b/log4go_test.go
@@ -57,6 +57,7 @@ var formatTests = []struct {
 		Formats: map[string]string{
 			// TODO(kevlar): How can I do this so it'll work outside of PST?
 			FORMAT_DEFAULT: "[2009/02/13 23:31:30 UTC] [EROR] (source) message\n",
+			FORMAT_MILLIS:  "[2009/02/13 23:31:30.123] [EROR] (source) message\n",
 			FORMAT_SHORT:   "[23:31 02/13/09] [EROR] message\n",
 			FORMAT_ABBREV:  "[EROR] message\n",
 		},


### PR DESCRIPTION
Add support for timestamps with millisecond precision (format code `%A`, since `%T`, `%t` and `%M` were taken). Millisecond timestamps aren't formatted unless the format is being used. 

There's also a small performance enhancement with caching the formatted date, which might offset the cost of re-computing millisecond timestamps.