### PR TITLE
ROCANA-2561 Add daily file rolling like log4j

### DIFF
--- a/config.go
+++ b/config.go
@@ -226,6 +226,18 @@ func strToNumSuffix(str string, mult int) int {
 	parsed, _ := strconv.Atoi(str)
 	return parsed * num
 }
+
+func parseRotateSuffix(value string) rotateSuffix {
+	switch value {
+	case "integer":
+		return intSuffix
+	case "date":
+		return dateSuffix
+	default:
+		return invalidSuffix
+	}
+}
+
 func xmlToFileLogWriter(filename string, props []xmlProperty, enabled bool) (*FileLogWriter, bool) {
 	file := ""
 	format := "[%D %T] [%L] (%S) %M"
@@ -233,6 +245,7 @@ func xmlToFileLogWriter(filename string, props []xmlProperty, enabled bool) (*Fi
 	maxsize := 0
 	daily := false
 	rotate := false
+	filenameSuffix := intSuffix
 
 	// Parse properties
 	for _, prop := range props {
@@ -249,6 +262,8 @@ func xmlToFileLogWriter(filename string, props []xmlProperty, enabled bool) (*Fi
 			daily = strings.Trim(prop.Value, " \r\n") != "false"
 		case "rotate":
 			rotate = strings.Trim(prop.Value, " \r\n") != "false"
+		case "rotateSuffix":
+			filenameSuffix = parseRotateSuffix(strings.Trim(prop.Value, " \r\n"))
 		default:
 			fmt.Fprintf(os.Stderr, "LoadConfiguration: Warning: Unknown property \"%s\" for file filter in %s\n", prop.Name, filename)
 		}
@@ -265,7 +280,7 @@ func xmlToFileLogWriter(filename string, props []xmlProperty, enabled bool) (*Fi
 		return nil, true
 	}
 
-	flw := NewFileLogWriter(file, rotate)
+	flw := NewFileLogWriter(file, rotate, filenameSuffix)
 	if flw == nil {
 		return nil, false
         }
@@ -282,6 +297,7 @@ func xmlToXMLLogWriter(filename string, props []xmlProperty, enabled bool) (*Fil
 	maxsize := 0
 	daily := false
 	rotate := false
+	filenameSuffix := intSuffix
 
 	// Parse properties
 	for _, prop := range props {
@@ -296,6 +312,8 @@ func xmlToXMLLogWriter(filename string, props []xmlProperty, enabled bool) (*Fil
 			daily = strings.Trim(prop.Value, " \r\n") != "false"
 		case "rotate":
 			rotate = strings.Trim(prop.Value, " \r\n") != "false"
+		case "rotateSuffix":
+			filenameSuffix = parseRotateSuffix(strings.Trim(prop.Value, " \r\n"))
 		default:
 			fmt.Fprintf(os.Stderr, "LoadConfiguration: Warning: Unknown property \"%s\" for xml filter in %s\n", prop.Name, filename)
 		}
@@ -312,7 +330,7 @@ func xmlToXMLLogWriter(filename string, props []xmlProperty, enabled bool) (*Fil
 		return nil, true
 	}
 
-	xlw := NewXMLLogWriter(file, rotate)
+	xlw := NewXMLLogWriter(file, rotate, filenameSuffix)
 	if xlw == nil {
 		return nil, false
 	}

--- a/filelog.go
+++ b/filelog.go
@@ -9,6 +9,16 @@ import (
 	"path"
 )
 
+type rotateSuffix int
+
+const (
+	invalidSuffix rotateSuffix = iota
+	intSuffix
+	dateSuffix
+)
+
+type nowFunc func() time.Time
+
 // This log writer sends output to a file
 type FileLogWriter struct {
 	rec chan *LogRecord
@@ -35,10 +45,17 @@ type FileLogWriter struct {
 
 	// Rotate daily
 	daily          bool
-	daily_opendate int
+	daily_opendate time.Time
 
-	// Keep old logfiles (.001, .002, etc)
+	// The suffix to append to rolled filenames
+	filenameSuffix	rotateSuffix
+
+	// Keep old logfiles
 	rotate bool
+
+	// In production this will always be time.Now(),
+	// exposed so we can set the time when testing
+	now nowFunc
 }
 
 // This is the FileLogWriter's output method
@@ -60,7 +77,7 @@ func (w *FileLogWriter) Close() {
 //
 // The standard log-line format is:
 //   [%D %T] [%L] (%S) %M
-func NewFileLogWriter(fname string, rotate bool) *FileLogWriter {
+func NewFileLogWriter(fname string, rotate bool, suffix rotateSuffix) *FileLogWriter {
 	w := &FileLogWriter{
 		rec:      make(chan *LogRecord, LogBufferLength),
 		rot:      make(chan bool),
@@ -68,6 +85,8 @@ func NewFileLogWriter(fname string, rotate bool) *FileLogWriter {
 		filename: fname,
 		format:   "[%D %T] [%L] (%S) %M",
 		rotate:   rotate,
+		filenameSuffix:   suffix,
+		now:	time.Now,
 	}
 
 	// If the directory doesn't exist, attempt to create it
@@ -79,7 +98,7 @@ func NewFileLogWriter(fname string, rotate bool) *FileLogWriter {
 	}
 
 	// open the file for the first time
-	if err := w.intRotate(); err != nil {
+	if err := w.handleRotate(); err != nil {
 		fmt.Fprintf(os.Stderr, "FileLogWriter(%q): %s\n", w.filename, err)
 		return nil
 	}
@@ -87,7 +106,7 @@ func NewFileLogWriter(fname string, rotate bool) *FileLogWriter {
 	go func() {
 		defer func() {
 			if w.file != nil {
-				fmt.Fprint(w.file, FormatLogRecord(w.trailer, &LogRecord{Created: time.Now()}))
+				fmt.Fprint(w.file, FormatLogRecord(w.trailer, &LogRecord{Created: w.now()}))
 				w.file.Close()
 			}
 		}()
@@ -104,11 +123,13 @@ func NewFileLogWriter(fname string, rotate bool) *FileLogWriter {
 					close(w.completed)
 					return
 				}
-				now := time.Now()
-				if (w.maxlines > 0 && w.maxlines_curlines >= w.maxlines) ||
+				now := w.now()
+				// maxlines isn't supported when using dateSuffix, because we don't scan the file
+				// to get the current number of lines.
+				if (w.maxlines > 0 && w.maxlines_curlines >= w.maxlines && w.filenameSuffix == intSuffix) ||
 					(w.maxsize > 0 && w.maxsize_cursize >= w.maxsize) ||
-					(w.daily && now.Day() != w.daily_opendate) {
-					if err := w.intRotate(); err != nil {
+					(w.daily && now.Day() != w.daily_opendate.Day()) {
+					if err := w.handleRotate(); err != nil {
 						fmt.Fprintf(os.Stderr, "FileLogWriter(%q): %s\n", w.filename, err)
 						return
 					}
@@ -136,14 +157,101 @@ func (w *FileLogWriter) Rotate() {
 	w.rot <- true
 }
 
-// If this is called in a threaded context, it MUST be synchronized
-func (w *FileLogWriter) intRotate() error {
+func (w *FileLogWriter) handleRotate() error {
+	// Distinguish between rolling the file at startup,
+	// and rolling the file because we saw the date change
+	startup := true
+
 	// Close any log file that may be open
 	if w.file != nil {
-		fmt.Fprint(w.file, FormatLogRecord(w.trailer, &LogRecord{Created: time.Now()}))
 		w.file.Close()
+		startup = false
+	}
+	switch (w.filenameSuffix) {
+	case dateSuffix:
+		return w.dateRotate(startup)
+	case intSuffix:
+		return w.intRotate()
+	default:
+		return fmt.Errorf("Invalid log filename format %v", w.filenameSuffix)
+	}
+}
+
+// Rotate the file, using the standard log4j format `filename-yyyy-MM-dd`.
+// If we're starting up we stat the existing file and use the last modified time to determine
+// whether to roll it. When there's an existing log file open (!startup), we always roll the log file.
+func (w *FileLogWriter) dateRotate(startup bool) error {
+	now := w.now()
+	stat, err := os.Lstat(w.filename)
+	if err == nil {
+		var logYear, logDay int
+		var logMonth time.Month
+		nowYear, nowMonth, nowDay := now.Date()
+
+		if startup {
+			// On startup, use the last modified time to figure out what the last timestamp
+			// in the file will be
+			logYear, logMonth, logDay = stat.ModTime().Date()
+
+			// If the file was written earlier today, append to it
+			if logDay == nowDay && logMonth == nowMonth && logYear == nowYear {
+				fd, err := os.OpenFile(w.filename, os.O_WRONLY|os.O_APPEND, 0660)
+				if err != nil {
+					return err
+				}
+				w.file = fd
+				w.daily_opendate = now
+				w.maxlines_curlines = 0
+				w.maxsize_cursize = int(stat.Size())
+				return nil
+			}
+		}  else {
+			// If we're rolling the log, use the day it was opened as the last timestamp
+			logYear, logMonth, logDay = w.daily_opendate.Date()
+		}
+
+		// Try to rename the file by appending the date. If this collides with an existing file,
+		// append a counter to the end to avoid data loss
+		var renamed bool
+		for i:=0; i < 999; i++ {
+			var fileName string
+			if i == 0 {
+				fileName = fmt.Sprintf("%s.%4d-%02d-%02d", w.filename, logYear, logMonth, logDay)
+			} else {
+				fileName = fmt.Sprintf("%s.%4d-%02d-%02d.%03d", w.filename, logYear, logMonth, logDay, i)
+			}
+			fmt.Printf("Trying to move %q to %q \n", w.filename, fileName)
+			if _, err := os.Lstat(fileName); os.IsNotExist(err) {
+				if err := os.Rename(w.filename, fileName); err != nil {
+					return fmt.Errorf("Rotate: Cannot rename file to %q: %v", fileName, err)
+				}
+				renamed = true
+				break
+			} else if err != nil {
+				return fmt.Errorf("Rotate: could not stat file %q: %v", fileName, err)
+			}
+		}
+		if !renamed {
+			return fmt.Errorf("Rotate: failed, could not find free log number %q", w.filename)
+		}
 	}
 
+	// Open a new log file
+	fd, err := os.OpenFile(w.filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0660)
+	if err != nil {
+		return err
+	}
+	w.file = fd
+
+	fmt.Fprint(w.file, FormatLogRecord(w.header, &LogRecord{Created: now}))
+
+	// Set the daily open date to the current date
+	w.daily_opendate = now
+	return nil
+}
+
+// If this is called in a threaded context, it MUST be synchronized
+func (w *FileLogWriter) intRotate() error {
 	// If we are keeping log files, move it to the next available number
 	if w.rotate {
 		_, err := os.Lstat(w.filename)
@@ -175,11 +283,11 @@ func (w *FileLogWriter) intRotate() error {
 	}
 	w.file = fd
 
-	now := time.Now()
+	now := w.now()
 	fmt.Fprint(w.file, FormatLogRecord(w.header, &LogRecord{Created: now}))
 
 	// Set the daily open date to the current date
-	w.daily_opendate = now.Day()
+	w.daily_opendate = now
 
 	// initialize rotation values
 	w.maxlines_curlines = 0
@@ -201,7 +309,7 @@ func (w *FileLogWriter) SetFormat(format string) *FileLogWriter {
 func (w *FileLogWriter) SetHeadFoot(head, foot string) *FileLogWriter {
 	w.header, w.trailer = head, foot
 	if w.maxlines_curlines == 0 {
-		fmt.Fprint(w.file, FormatLogRecord(w.header, &LogRecord{Created: time.Now()}))
+		fmt.Fprint(w.file, FormatLogRecord(w.header, &LogRecord{Created: w.now()}))
 	}
 	return w
 }
@@ -242,8 +350,8 @@ func (w *FileLogWriter) SetRotate(rotate bool) *FileLogWriter {
 
 // NewXMLLogWriter is a utility method for creating a FileLogWriter set up to
 // output XML record log messages instead of line-based ones.
-func NewXMLLogWriter(fname string, rotate bool) *FileLogWriter {
-	return NewFileLogWriter(fname, rotate).SetFormat(
+func NewXMLLogWriter(fname string, rotate bool, suffix rotateSuffix) *FileLogWriter {
+	return NewFileLogWriter(fname, rotate, suffix).SetFormat(
 		`	<record level="%L">
 		<timestamp>%D %T</timestamp>
 		<source>%S</source>


### PR DESCRIPTION
This adds an option to use daily rolling like log4j: within a day, restarts of the program will append to the same file. At midnight the file will be rolled to a new, timestamped file. On startup, if the log's last-modified date is from an earlier day it will be rolled.

This PR doesn't attempt to scan the existing log in any way, so we use the filesystem modified time as a heuristic for rolling existing logs on startup. It also doesn't support rolling on a maximum number of lines, since we don't know how many lines an existing log has at startup. Rolling based on size is still supported everywhere.

edit: Added support for trailers - if the application has been gone for a day, the trailer will get written on startup when the file is rolled. I'm not sure if there's a more intuitive behaviour.