### PR TITLE
ROCANA-1481: Log rotation naming different from other log files

### DIFF
--- a/config.go
+++ b/config.go
@@ -233,6 +233,7 @@ func xmlToFileLogWriter(filename string, props []xmlProperty, enabled bool) (*Fi
 	maxsize := 0
 	daily := false
 	rotate := false
+	dateSuffix := false
 
 	// Parse properties
 	for _, prop := range props {
@@ -249,6 +250,8 @@ func xmlToFileLogWriter(filename string, props []xmlProperty, enabled bool) (*Fi
 			daily = strings.Trim(prop.Value, " \r\n") != "false"
 		case "rotate":
 			rotate = strings.Trim(prop.Value, " \r\n") != "false"
+		case "datesuffix":
+			dateSuffix = strings.Trim(prop.Value, " \r\n") != "false"
 		default:
 			fmt.Fprintf(os.Stderr, "LoadConfiguration: Warning: Unknown property \"%s\" for file filter in %s\n", prop.Name, filename)
 		}
@@ -273,6 +276,7 @@ func xmlToFileLogWriter(filename string, props []xmlProperty, enabled bool) (*Fi
 	flw.SetRotateLines(maxlines)
 	flw.SetRotateSize(maxsize)
 	flw.SetRotateDaily(daily)
+	flw.SetRotateDateSuffix(dateSuffix)
 	return flw, true
 }
 


### PR DESCRIPTION
This commit uses a date suffix for log files and rotates the current log file when the date changes. Features like rotation on max lines and file size are preserved.