### PR TITLE
ROCANA-5151: Update log4go package paths

### DIFF
--- a/examples/ConsoleLogWriter_Manual.go
+++ b/examples/ConsoleLogWriter_Manual.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-import l4g "code.google.com/p/log4go"
+import l4g "github.com/scalingdata/log4go"
 
 func main() {
 	log := l4g.NewLogger()

--- a/examples/FileLogWriter_Manual.go
+++ b/examples/FileLogWriter_Manual.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-import l4g "code.google.com/p/log4go"
+import l4g "github.com/scalingdata/log4go"
 
 const (
 	filename = "flw.log"

--- a/examples/SocketLogWriter_Manual.go
+++ b/examples/SocketLogWriter_Manual.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-import l4g "code.google.com/p/log4go"
+import l4g "github.com/scalingdata/log4go"
 
 func main() {
 	log := l4g.NewLogger()

--- a/examples/XMLConfigurationExample.go
+++ b/examples/XMLConfigurationExample.go
@@ -1,6 +1,6 @@
 package main
 
-import l4g "code.google.com/p/log4go"
+import l4g "github.com/scalingdata/log4go"
 
 func main() {
 	// Load the configuration (isn't this easy?)


### PR DESCRIPTION
The log4go examples have code.google.com/p/log4go package imports. Now that google code has shut down, the jenkins job fails until these imports are fixed.